### PR TITLE
Use UUIDs to keep track of unlocked inventory

### DIFF
--- a/src/attire.ts
+++ b/src/attire.ts
@@ -16,6 +16,7 @@ export interface PresentationAttire extends Attire {
      *  3 = everywhere
      */
     tier: LootboxTier
+    /** A UUID number which is used to represent the attire on playfab to save disk space */
     uuid: number
 }
 

--- a/src/attire/attireSets.ts
+++ b/src/attire/attireSets.ts
@@ -15,6 +15,8 @@ export interface AttireSet {
 
     /** Who should we say built this */
     attributedTo: string
+
+    /** Provide a link back to them */
     attributedURL: string
 
     lightHexColor: string
@@ -29,3 +31,24 @@ export const allAttireSets = [defaultAttireSet, dangerAttireSet, happyChapAttire
 
 /** All of the attire available in the game ATM */
 export const allAttireInGame = [...defaultAttireSet.attire, ...dangerAttireSet.attire, ...happyChapAttireSet.attire]
+
+const allAttireKeyedByUUID = {} as { [index: number]: PresentationAttire }
+const allAttireKeyedByID = {} as { [index: string]: PresentationAttire }
+
+allAttireInGame.forEach(attire => {
+    allAttireKeyedByUUID[attire.uuid] = attire
+    allAttireKeyedByID[attire.id] = attire
+})
+
+// > let a = {}
+// undefined
+// > a[1] = "123"
+// '123'
+// > a["1"]
+// '123'
+// > a[1]
+// '123'
+/** Quickly goes from 1 -> "hedgehog" */
+export const convertAttireUUIDToID = (uuid: string | number) => allAttireKeyedByUUID[uuid as any].id
+/** Quickly goes from hedgehog -> 1 */
+export const convertAttireIDToUUID = (id: string) => allAttireKeyedByID[id].uuid

--- a/src/playFab.ts
+++ b/src/playFab.ts
@@ -3,9 +3,8 @@ import { Attire, defaultAttire } from "./attire"
 import _ = require("lodash")
 import { cache } from "./localCache"
 import { titleId } from "../assets/config/playfabConfig"
-import { GameMode } from "./battle/utils/gameMode"
 import { APIVersion } from "./constants"
-import { allAttireInGame } from "./attire/attireSets"
+import { allAttireInGame, convertAttireUUIDToID } from "./attire/attireSets"
 import { changeSettings, syncedSettingsKeys, updateUserStatisticsFromPlayFab } from "./user/userManager"
 import { UserSettings } from "./user/UserSettingsTypes"
 import playfabPromisify from "./playfabPromisify"
@@ -269,7 +268,14 @@ const handleCombinedPayload = async (payload: PlayFabClientModels.GetPlayerCombi
         })
 
         if (payload.UserData && payload.UserData.unlockedAttire && payload.UserData.unlockedAttire.Value) {
-            const attire = payload.UserData.unlockedAttire.Value.split(",")
+            let attire = payload.UserData.unlockedAttire.Value.split(",")
+            if (attire[0]) {
+                // Basically if it's an array of numbers as strings, which are the
+                // attire UUIDs, all new code works this way
+                if (!isNaN(Number(attire[0]))) {
+                    attire = attire.map(convertAttireUUIDToID)
+                }
+            }
             changeSettings({
                 unlockedAttire: attire
             })

--- a/src/scripts/uploadAttireCatalog.ts
+++ b/src/scripts/uploadAttireCatalog.ts
@@ -25,6 +25,7 @@ const attireToCatalogItem = (item: PresentationAttire): PlayFabAdminModels.Catal
         Tags: tags,
         Description: item.description,
         ItemClass: itemClass,
+        DisplayName: item.uuid.toString(),
 
         CanBecomeCharacter: false,
         InitialLimitedEditionCount: 0,


### PR DESCRIPTION
When receiving or settings `unlockedAttire` it will keep UUIDs on the server, and convert to IDs on the client